### PR TITLE
Fix compilation on older Visual Studio C++ copies

### DIFF
--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -13,7 +13,6 @@
 #include <wchar.h>
 #include <stdio.h>
 #include <assert.h>
-#include <atlbase.h>
 #include <windows.h>
 #include <ShObjIdl.h>
 


### PR DESCRIPTION
"atlbase.h" is not included in older Visual Studio C++ Express versions, after removing it, things appear to work fine, both with new and old versions of Visual Studio Express, so it doesn't appear to be needed. Thanks! :smile: