### PR TITLE
nfd_gtk – perform all GTK+ operations in a forked process

### DIFF
--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -33,24 +33,20 @@ int NFDi_write(int fd, size_t sz, void const *buf)
 	char const * const p = buf;
 	do {
 		int write_errno;
-		do {
-			rc = write(fd, (p + tot), (sz - tot));
-			if( 0 > rc ) {
-				write_errno = errno;
-				switch( write_errno ) {
-				case EAGAIN:
-					usleep(100);
-				case EINTR:
-					rc = 0;
-				default:
-					break;
-				}
-			}
-		} while( 0 > rc );
+redo_write:
+		rc = write(fd, (p + tot), (sz - tot));
 		if( 0 > rc ) {
-			return write_errno;
-		} else
-		if( (0 == rc) && (tot < sz) ) {
+			write_errno = errno;
+			switch( write_errno ) {
+			case EAGAIN: usleep(100);
+			case EINTR:
+				goto redo_write;
+
+			default:
+				return write_errno;
+			}
+		}
+		if( !rc && (tot < sz) ) {
 			return ESHUTDOWN;
 		}
 		tot += rc;
@@ -67,24 +63,20 @@ int NFDi_read(int fd, size_t sz, void *buf)
 	char * const p = buf;
 	do {
 		int read_errno;
-		do {
-			rc = read(fd, (p + tot), (sz - tot));
-			if( 0 > rc ) {
-				read_errno = errno;
-				switch( read_errno ) {
-				case EAGAIN:
-					usleep(100);
-				case EINTR:
-					rc = 0;
-				default:
-					break;
-				}
-			}
-		} while( 0 > rc );
+redo_read:
+		rc = read(fd, (p + tot), (sz - tot));
 		if( 0 > rc ) {
-			return read_errno;
-		} else
-		if( (0 == rc) && (tot < sz) ) {
+			read_errno = errno;
+			switch( read_errno ) {
+			case EAGAIN: usleep(100);
+			case EINTR:
+				goto redo_read;
+
+			default:
+				return read_errno;
+			}
+		}
+		if( !rc && (tot < sz) ) {
 			return ESHUTDOWN;
 		}
 		tot += rc;

--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -334,19 +334,6 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
 			);
 		}
 		close(fd_pipe[1]);
-#if RUNNING_ON_VALGRIND
-		/* There's not really a need to free the memory allocated by
-		 * NFDi_OpenDialog_F here; the process is about to get torn down
-		 * anyway and cleaning up is akin to give a house a paint job
-		 * before the demolishion crew applies a wrecking ball to it.
-		 *
-		 * But when Valgrind is running we do it to keep happy the
-		 * trained monkeys who're conditioned to react to certain output
-		 * of certain analysis tools by filing bug reports and issues.
-		 * It's not an issue, but it keeps these people off of our
-		 * collective behinds. */
-		free(buf);
-#endif
 		_exit( result );
 	}
 	/* close the writing end of the pipe in the parent process. */
@@ -469,19 +456,6 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
 			);
 		}
 		close(fd_pipe[1]);
-#if RUNNING_ON_VALGRIND
-		/* There's not really a need to free the memory allocated by
-		 * NFDi_OpenDialogMultiple_F here; the process is about to get torn down
-		 * anyway and cleaning up is akin to give a house a paint job
-		 * before the demolishion crew applies a wrecking ball to it.
-		 *
-		 * But when Valgrind is running we do it to keep happy the
-		 * trained monkeys who're conditioned to react to certain output
-		 * of certain analysis tools by filing bug reports and issues.
-		 * It's not an issue, but it keeps these people off of our
-		 * collective behinds. */
-		free(buf);
-#endif
 		_exit( result );
 	}
 	/* close the writing end of the pipe in the parent process. */
@@ -622,19 +596,6 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
 			);
 		}
 		close(fd_pipe[1]);
-#if RUNNING_ON_VALGRIND
-		/* There's not really a need to free the memory allocated by
-		 * NFD_SaveDialog_F here; the process is about to get torn down
-		 * anyway and cleaning up is akin to give a house a paint job
-		 * before the demolishion crew applies a wrecking ball to it.
-		 *
-		 * But when Valgrind is running we do it to keep happy the
-		 * trained monkeys who're conditioned to react to certain output
-		 * of certain analysis tools by filing bug reports and issues.
-		 * It's not an issue, but it keeps these people off of our
-		 * collective behinds. */
-		free(buf);
-#endif
 		_exit( result );
 	}
 	/* close the writing end of the pipe in the parent process. */


### PR DESCRIPTION
Hi, this pull request covers a small patch that augments the GTK+ code with a forking wrapper. This essentially encapsulates everything GTK+ into a separate process. Aside solving the GTK+ deinitialization issue this also improves robustness of the host program: If anything on the GTK side crashes the process (for example a bug in a thumbnail generator or similar), only the process dedicated to the file dialog goes down and the host process sees an error. Another benefit of forking the file dialog is, that in case a networked file system is accessed and the network blocks one can kill the file dialog process without tearing down the host.

Q&A:

- When run in a memory debugger memory leaks are reported:
Yes, the file dialog process exits without freeing the buffers it created. That would be like giving a house a cleanup and paint job just before the demolishion crew goes to work.

- There's no proper serialization format being used in the pipe. It just transmits raw binary in-memory data.
Yes, the pipe is accessed by literally the very same binary (with identical virtual addresses for everything) that runs in two separate processes and the pipe transfers simply connect identical memory layouts of objects on both processes. There's no need for a descriptive serialization format here. Admittedly, someone could inject nonsense into /proc/fd/${PIPE} but there are easier ways to mess up things.