### PR TITLE
support for multiple CFLAGS (gcc didn't want to compile)

### DIFF
--- a/src/SConstruct
+++ b/src/SConstruct
@@ -36,7 +36,7 @@ else:
 for env_key in IMPORT_FROM_ENV:
     if env_key in os.environ:
         print "Making %s => %s" % ( env_key, os.environ[env_key] )
-        nfd_env[env_key] = os.environ[env_key]
+        nfd_env[env_key] = os.environ[env_key].split()
 
 # Windows runtime library types
 win_rtl = {'debug': '/MDd',     


### PR DESCRIPTION
Output before commit:
```
[fabio@archbox src]$ echo $CFLAGS
-march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong
[fabio@archbox src]$ scons debug=0
scons: Reading SConscript files ...
Making CFLAGS => -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong
scons: done reading SConscript files.
scons: Building targets ...
gcc -o nfd_common.o -c "-march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong" -O3 -Wall -pedantic -pthread -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libdrm -I/usr/include/gdk-pixbuf-2.0 -I. -Iinclude nfd_common.c
nfd_common.c:1:0: error: bad value (x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong) for -march= switch
 /*
 
scons: *** [nfd_common.o] Error 1
scons: building terminated because of errors.
```

Output after commit:
```
[fabio@archbox src]$ scons debug=0
scons: Reading SConscript files ...
Making CFLAGS => -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong
scons: done reading SConscript files.
scons: Building targets ...
gcc -o nfd_common.o -c -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -O3 -Wall -pedantic -pthread -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libdrm -I/usr/include/gdk-pixbuf-2.0 -I. -Iinclude nfd_common.c
gcc -o nfd_gtk.o -c -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -O3 -Wall -pedantic -pthread -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libdrm -I/usr/include/gdk-pixbuf-2.0 -I. -Iinclude nfd_gtk.c
In file included from /usr/include/glib-2.0/gobject/gobject.h:26:0,
                 from /usr/include/glib-2.0/gobject/gbinding.h:29,
                 from /usr/include/glib-2.0/glib-object.h:23,
                 from /usr/include/glib-2.0/gio/gioenums.h:28,
                 from /usr/include/glib-2.0/gio/giotypes.h:28,
                 from /usr/include/glib-2.0/gio/gio.h:26,
                 from /usr/include/gtk-3.0/gdk/gdkapplaunchcontext.h:28,
                 from /usr/include/gtk-3.0/gdk/gdk.h:32,
                 from /usr/include/gtk-3.0/gtk/gtk.h:30,
                 from nfd_gtk.c:10:
/usr/include/glib-2.0/gobject/gparam.h:166:33: warning: enumerator value for 'G_PARAM_DEPRECATED' is not an integer constant expression [-Wpedantic]
   G_PARAM_DEPRECATED          = 1 << 31
                                 ^
ar rc libnfd.a nfd_common.o nfd_gtk.o
ranlib libnfd.a
scons: done building targets.
```

The difference is in the missing quotes around the CFLAGS passed to gcc.