### PR TITLE
Enable travis-ci for Linux and OSX builds, enable AppVeyor for Windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+dist: trusty
+
+language: cpp
+
+# You must contact travis-ci support to enable OSX builds
+os:
+ - linux
+ - osx
+
+matrix:
+ - config=release_x86
+ - config=release_x64
+ - config=debug_x86
+ - config=debug_x64
+
+compiler:
+- gcc
+- clang
+
+install:
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update; fi
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libgtk-3-dev; fi
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then  sudo apt-get install g++-multilib; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
+
+script: 
+- $CXX --version
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then cd build/gmake_linux; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then cd build/gmake_macosx; fi
+- make config=release_x64

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Features:
  - GTK+3 dialog on Linux.
  - Tested, works alongside [http://www.libsdl.org](SDL2) on all platforms, for the game developers out there.
 
+
+Branch  | Linux/OSX | Windows
+------------- | ------------- | -------------
+master |[![Build status](https://travis-ci.org/mlabbe/nativefiledialog.svg?branch=master)](https://travis-ci.org/mlabbe/nativefiledialog) | [![Build status](https://ci.appveyor.com/api/projects/status/s29llemvnadkw83c/branch/master?svg=true)](https://ci.appveyor.com/project/mlabbe/nativefiledialog/branch/master)
+devel | [![Build Status](https://travis-ci.org/mlabbe/nativefiledialog.svg?branch=devel)](https://travis-ci.org/mlabbe/nativefiledialog) | [![Build status](https://ci.appveyor.com/api/projects/status/s29llemvnadkw83c/branch/devel?svg=true)](https://ci.appveyor.com/project/mlabbe/nativefiledialog/branch/devel)
+
 # Example Usage #
 
 ```C

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 1.0.{build}
+
+platform:
+ - x86
+configuration:
+ - Release
+
+clone_folder: c:\nfd
+
+before_build:
+- call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+
+build_script:
+- cd build\vs2010
+- msbuild NativeFileDialog.sln /p:Configuration=Release /p:Platform="Win32"
+
+test: off


### PR DESCRIPTION
This will enable auto builds on push/pull requests to check everything still compile as seen here:

Linux/OSX:
https://travis-ci.org/paulsapps/nativefiledialog/builds/153936808

Windows:
https://ci.appveyor.com/project/paulsapps/nativefiledialog/build/1.0.10

To make this work on the main repo you will have to login to each of these services and enable it.

Edit: Seems appveyor is already enabled here? Either way a build seems to have started by magic!