### PR TITLE
Add shared library build config

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -12,7 +12,7 @@ workspace "NativeFileDialog"
   -- into a subdirectory.  ex: $root/build/makefile
   local root_dir = path.join(path.getdirectory(_SCRIPT),"../../")
   local build_dir = path.join(root_dir,"build/")
-  configurations { "Release", "Debug" }
+  configurations { "Release", "ReleaseDLL", "Debug", "DebugDLL" }
   platforms {"x64", "x86"}
 
   objdir(path.join(build_dir, "obj/"))
@@ -36,6 +36,9 @@ workspace "NativeFileDialog"
 
   project "nfd"
     kind "StaticLib"
+    filter "configurations:*DLL"
+      kind "SharedLib"
+    filter {}
 
     -- common files
     files {root_dir.."src/*.h",


### PR DESCRIPTION
I needed a shared library for my [.NET wrapper](https://github.com/benklett/nfd-sharp). I thought I would share this "feature" so others can use it as well.