### PR TITLE
Add programming interface for modal dialogs

### DIFF
--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -39,21 +39,35 @@ typedef enum {
 nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath );
+nfdresult_t NFD_OpenDialogEx( const nfdchar_t *filterList,
+                              const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent );
 
 /* multiple file open dialog */    
 nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
                                     const nfdchar_t *defaultPath,
                                     nfdpathset_t *outPaths );
+nfdresult_t NFD_OpenDialogMultipleEx( const nfdchar_t *filterList,
+                                      const nfdchar_t *defaultPath,
+                                      nfdpathset_t *outPaths,
+                                      void *parent );
 
 /* save dialog */
 nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath );
-
+nfdresult_t NFD_SaveDialogEx( const nfdchar_t *filterList,
+                              const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent );
 
 /* select folder dialog */
 nfdresult_t NFD_PickFolder( const nfdchar_t *defaultPath,
-                            nfdchar_t **outPath);
+                            nfdchar_t **outPath );
+nfdresult_t NFD_PickFolderEx( const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent );
 
 /* nfd_common.c */
 

--- a/src/nfd_cocoa.m
+++ b/src/nfd_cocoa.m
@@ -116,10 +116,17 @@ static nfdresult_t AllocPathSet( NSArray *urls, nfdpathset_t *pathset )
 
 /* public */
 
-
 nfdresult_t NFD_OpenDialog( const char *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath )
+{
+    NFD_OpenDialogEx(filterList, defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_OpenDialogEx( const char *filterList,
+                              const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent )
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
@@ -157,10 +164,17 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
     return nfdResult;
 }
 
-
 nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
                                     const nfdchar_t *defaultPath,
                                     nfdpathset_t *outPaths )
+{
+    return NFD_OpenDialogMultipleEx(filterList, defaultPath, outPaths, NULL);
+}
+
+nfdresult_t NFD_OpenDialogMultipleEx( const nfdchar_t *filterList,
+                                      const nfdchar_t *defaultPath,
+                                      nfdpathset_t *outPaths,
+                                      void *parent )
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     
@@ -197,10 +211,17 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
     return nfdResult;
 }
 
-
 nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath )
+{
+    return NFD_SaveDialogEx(filterList, defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_SaveDialogEx( const nfdchar_t *filterList,
+                              const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent )
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
@@ -236,8 +257,15 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
     return nfdResult;
 }
 
-nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
-    nfdchar_t **outPath)
+nfdresult_t NFD_PickFolder( const nfdchar_t *defaultPath,
+                            nfdchar_t **outPath )
+{
+    return NFD_PickFolderEx(defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_PickFolderEx( const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent )
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 

--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -168,6 +168,14 @@ static void WaitForCleanup(void)
 nfdresult_t NFD_OpenDialog( const char *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath )
+{
+    return NFD_OpenDialogEx(filterList, defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_OpenDialogEx( const char *filterList,
+                            const nfdchar_t *defaultPath,
+                            nfdchar_t **outPath,
+                            void *parent )
 {    
     GtkWidget *dialog;
     nfdresult_t result;
@@ -179,7 +187,7 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
     }
 
     dialog = gtk_file_chooser_dialog_new( "Open File",
-                                          NULL,
+                                          (GtkWindow*)(parent),
                                           GTK_FILE_CHOOSER_ACTION_OPEN,
                                           "_Cancel", GTK_RESPONSE_CANCEL,
                                           "_Open", GTK_RESPONSE_ACCEPT,
@@ -221,10 +229,17 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
     return result;
 }
 
-
 nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
                                     const nfdchar_t *defaultPath,
                                     nfdpathset_t *outPaths )
+{
+    NFD_OpenDialogMultipleEx(filterList, defaultPath, outPaths, NULL);
+}
+
+nfdresult_t NFD_OpenDialogMultipleEx( const nfdchar_t *filterList,
+                                      const nfdchar_t *defaultPath,
+                                      nfdpathset_t *outPaths,
+                                      void *parent )
 {
     GtkWidget *dialog;
     nfdresult_t result;
@@ -236,7 +251,7 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
     }
 
     dialog = gtk_file_chooser_dialog_new( "Open Files",
-                                          NULL,
+                                          (GtkWindow*)(parent),
                                           GTK_FILE_CHOOSER_ACTION_OPEN,
                                           "_Cancel", GTK_RESPONSE_CANCEL,
                                           "_Open", GTK_RESPONSE_ACCEPT,
@@ -273,6 +288,14 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath )
 {
+    NFD_SaveDialogEx(filterList, defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_SaveDialogEx( const nfdchar_t *filterList,
+                              const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent )
+{
     GtkWidget *dialog;
     nfdresult_t result;
 
@@ -283,7 +306,7 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
     }
 
     dialog = gtk_file_chooser_dialog_new( "Save File",
-                                          NULL,
+                                          (GtkWindow*)(parent),
                                           GTK_FILE_CHOOSER_ACTION_SAVE,
                                           "_Cancel", GTK_RESPONSE_CANCEL,
                                           "_Save", GTK_RESPONSE_ACCEPT,
@@ -325,8 +348,15 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
     return result;
 }
 
-nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
-    nfdchar_t **outPath)
+nfdresult_t NFD_PickFolder( const nfdchar_t *defaultPath,
+                            nfdchar_t **outPath )
+{
+    NFD_PickFolderEx(defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_PickFolderEx( const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent )
 {
     GtkWidget *dialog;
     nfdresult_t result;
@@ -338,7 +368,7 @@ nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
     }
 
     dialog = gtk_file_chooser_dialog_new( "Select folder",
-                                          NULL,
+                                          (GtkWindow*)(parent),
                                           GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
                                           "_Cancel", GTK_RESPONSE_CANCEL,
                                           "_Select", GTK_RESPONSE_ACCEPT,

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -353,9 +353,17 @@ static nfdresult_t SetDefaultPath( IFileDialog *dialog, const char *defaultPath 
 /* public */
 
 
-nfdresult_t NFD_OpenDialog( const char *filterList,
+nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath )
+{
+    return NFD_OpenDialogEx(filterList, defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_OpenDialogEx( const nfdchar_t *filterList,
+                              const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent )
 {
     nfdresult_t nfdResult = NFD_ERROR;
     
@@ -396,7 +404,7 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
     }    
 
     // Show the dialog.
-    result = fileOpenDialog->Show(NULL);
+    result = fileOpenDialog->Show(reinterpret_cast<HWND>(parent));
     if ( SUCCEEDED(result) )
     {
         // Get the file name
@@ -445,6 +453,14 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
 nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
                                     const nfdchar_t *defaultPath,
                                     nfdpathset_t *outPaths )
+{
+    return NFD_OpenDialogMultipleEx(filterList, defaultPath, outPaths, NULL);
+}
+
+nfdresult_t NFD_OpenDialogMultipleEx( const nfdchar_t *filterList,
+                                      const nfdchar_t *defaultPath,
+                                      nfdpathset_t *outPaths,
+                                      void *parent )
 {
     nfdresult_t nfdResult = NFD_ERROR;
     
@@ -499,7 +515,7 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
     }
  
     // Show the dialog.
-    result = fileOpenDialog->Show(NULL);
+    result = fileOpenDialog->Show(reinterpret_cast<HWND>(parent));
     if ( SUCCEEDED(result) )
     {
         IShellItemArray *shellItems;
@@ -537,6 +553,14 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
 nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath )
+{
+    return NFD_SaveDialogEx(filterList, defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_SaveDialogEx( const nfdchar_t *filterList,
+                              const nfdchar_t *defaultPath,
+                              nfdchar_t **outPath,
+                              void *parent )
 {
     nfdresult_t nfdResult = NFD_ERROR;
     
@@ -576,7 +600,7 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
     }
 
     // Show the dialog.
-    result = fileSaveDialog->Show(NULL);
+    result = fileSaveDialog->Show(reinterpret_cast<HWND>(parent));
     if ( SUCCEEDED(result) )
     {
         // Get the file name
@@ -669,8 +693,15 @@ private:
     T* mPtr;
 };
 
-nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
-    nfdchar_t **outPath)
+nfdresult_t NFD_PickFolder( const nfdchar_t *defaultPath, 
+                            nfdchar_t **outPath )
+{
+    return NFD_PickFolderEx(defaultPath, outPath, NULL);
+}
+
+nfdresult_t NFD_PickFolderEx( const nfdchar_t *defaultPath, 
+                            nfdchar_t **outPath,
+                            void *parent )
 {
     // Init COM
     AutoCoInit autoCoInit;
@@ -714,7 +745,7 @@ nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
     }
 
     // Show the dialog to the user
-    const HRESULT result = pFileDialog->Show(NULL);
+    const HRESULT result = pFileDialog->Show(reinterpret_cast<HWND>(parent));
     if (result == HRESULT_FROM_WIN32(ERROR_CANCELLED))
     {
         return NFD_CANCEL;


### PR DESCRIPTION
Greetings! I noticed that nfd does not currently support modal dialogs; windows that force the user to interact with it before returning to a parent application. As I needed this behavior I have adapted the code of this library rather than write the whole thing myself. Perhaps the changes are useful for others as well.

Note that I have only tested this on Windows 10. The changes made for the GTK version _should_ be correct as well, looking at the API documentation. Furthermore, since I have no experience with Cocoa, I am uncertain how modals work on OSX, but a quick glance at the API suggests that calling function `runModal` should already open a modal window as is in the current version.