### PR TITLE
Fix zenity --filename argument

### DIFF
--- a/src/nfd_zenity.c
+++ b/src/nfd_zenity.c
@@ -92,7 +92,7 @@ static nfdresult_t ZenityCommon(char** command, int commandLen, const char* defa
 {
     if(defaultPath != NULL)
     {
-        char* prefix = "--filename";
+        char* prefix = "--filename=";
         int len = strlen(prefix) + strlen(defaultPath) + 1;
 
         char* tmp = (char*) calloc(len, 1);


### PR DESCRIPTION
The prefix and path are just concatenated so without this change the argument would be `--filename/path/to/file`.
This is not a valid argument to zenity; it need a `=` character between to make it `--filename=/path/to/file`.