### PR TITLE
Fix MinGW requiring fpermissive to compile

### DIFF
--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -372,6 +372,8 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
 
     ::IFileOpenDialog *fileOpenDialog(NULL);
 
+    HRESULT result;
+
     if ( !SUCCEEDED(coResult))
     {
         fileOpenDialog = NULL;
@@ -380,7 +382,7 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
     }
 
     // Create dialog
-    HRESULT result = ::CoCreateInstance(::CLSID_FileOpenDialog, NULL,
+    result = ::CoCreateInstance(::CLSID_FileOpenDialog, NULL,
                                         CLSCTX_ALL, ::IID_IFileOpenDialog,
                                         reinterpret_cast<void**>(&fileOpenDialog) );
                                 


### PR DESCRIPTION
This is the error I get otherwise:
```
../../src/nfd_win.cpp: In function 'nfdresult_t NFD_OpenDialog(const nfdchar_t*, const nfdchar_t*, nfdchar_t**)':
../../src/nfd_win.cpp:448:1: error: jump to label 'end' [-fpermissive]
 end:
 ^~~
../../src/nfd_win.cpp:379:14: note:   from here
         goto end;
              ^~~
../../src/nfd_win.cpp:383:13: note:   crosses initialization of 'HRESULT result'
     HRESULT result = ::CoCreateInstance(::CLSID_FileOpenDialog, NULL,
             ^~~~~~
```