### PR TITLE
Handle RPC_E_CHANGED_MODE return value from CoInitializeEx better.

### DIFF
--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -372,7 +372,7 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
 
     ::IFileOpenDialog *fileOpenDialog(NULL);
 
-    if ( !SUCCEEDED(coResult))
+    if ( !SUCCEEDED(coResult) && coResult != RPC_E_CHANGED_MODE )
     {
         fileOpenDialog = NULL;
         NFDi_SetError("Could not initialize COM.");
@@ -449,7 +449,7 @@ end:
     if (fileOpenDialog)
         fileOpenDialog->Release();
 
-    if (SUCCEEDED(coResult))
+    if (SUCCEEDED(coResult) && coResult != RPC_E_CHANGED_MODE)
         ::CoUninitialize();
     
     return nfdResult;

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -4,8 +4,8 @@
   http://www.frogtoss.com/labs
  */
 
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
+#define _CRTDBG_MAP_ALLOC  
+#include <stdlib.h>  
 #include <crtdbg.h>  
 
 /* only locally define UNICODE in this compilation unit */
@@ -451,7 +451,7 @@ end:
 
     if (SUCCEEDED(coResult))
         ::CoUninitialize();
-
+    
     return nfdResult;
 }
 

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -4,8 +4,8 @@
   http://www.frogtoss.com/labs
  */
 
-#define _CRTDBG_MAP_ALLOC  
-#include <stdlib.h>  
+#define _CRTDBG_MAP_ALLOC
+#include <stdlib.h>
 #include <crtdbg.h>  
 
 /* only locally define UNICODE in this compilation unit */
@@ -449,9 +449,9 @@ end:
     if (fileOpenDialog)
         fileOpenDialog->Release();
 
-    if (SUCCEEDED(coResult) && coResult != RPC_E_CHANGED_MODE)
+    if (SUCCEEDED(coResult))
         ::CoUninitialize();
-    
+
     return nfdResult;
 }
 
@@ -465,7 +465,7 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
     HRESULT coResult = ::CoInitializeEx(NULL,
                                         ::COINIT_APARTMENTTHREADED |
                                         ::COINIT_DISABLE_OLE1DDE );
-    if ( !SUCCEEDED(coResult))
+    if ( !SUCCEEDED(coResult) && coResult != RPC_E_CHANGED_MODE )
     {
         NFDi_SetError("Could not initialize COM.");
         return NFD_ERROR;
@@ -563,7 +563,7 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
     HRESULT coResult = ::CoInitializeEx(NULL,
                                         ::COINIT_APARTMENTTHREADED |
                                         ::COINIT_DISABLE_OLE1DDE );
-    if ( !SUCCEEDED(coResult))
+    if ( !SUCCEEDED(coResult) && coResult != RPC_E_CHANGED_MODE )
     {
         NFDi_SetError("Could not initialize COM.");
         return NFD_ERROR;
@@ -666,7 +666,10 @@ public:
         }
     }
 
-    HRESULT Result() const { return mResult; }
+    // Eat RPC_E_CHANGED_MODE - it means we couldn't change the mode, but COM still works
+    // for our purposes.
+    HRESULT Result() const { return mResult == RPC_E_CHANGED_MODE ? S_OK : mResult; }
+
 private:
     HRESULT mResult;
 };


### PR DESCRIPTION
Fixes https://github.com/mlabbe/nativefiledialog/issues/72.

This is my proposal for a minimal-impact fix for the issue. I don't know if anyone really still uses COINIT_APARTMENTTHREADED mode though.

When CoInitializeEx returns RPC_E_CHANGED_MODE, it's not because it actually changed the mode but because you requested an invalid mode change, which didn't actually happen. COM still works in the old mode. So handling this error and avoiding calling CoUninitialize fixes this with zero impact to existing code.