### PR TITLE
NULL-pointer dereference fix and wrapper for free()ing allocated paths

### DIFF
--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -59,6 +59,8 @@ nfdresult_t NFD_PickFolder( const nfdchar_t *defaultPath,
 
 /* get last error -- set when nfdresult_t returns NFD_ERROR */
 const char *NFD_GetError( void );
+/* Free the path returned by NFD_OpenDialog et al. */
+void        NFD_Path_Free( nfdchar_t *path );
 /* get the number of entries stored in pathSet */
 size_t      NFD_PathSet_GetCount( const nfdpathset_t *pathSet );
 /* Get the UTF-8 path at offset index */

--- a/src/nfd_common.c
+++ b/src/nfd_common.c
@@ -18,6 +18,11 @@ const char *NFD_GetError( void )
     return g_errorstr;
 }
 
+void NFD_Path_Free( nfdchar_t *path )
+{
+    NFDi_Free( path );
+}
+
 size_t NFD_PathSet_GetCount( const nfdpathset_t *pathset )
 {
     assert(pathset);

--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -201,13 +201,13 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
         {
             size_t len = strlen(filename);
             *outPath = NFDi_Malloc( len + 1 );
-            memcpy( *outPath, filename, len + 1 );
             if ( !*outPath )
             {
                 g_free( filename );
                 gtk_widget_destroy(dialog);
                 return NFD_ERROR;
             }
+            memcpy( *outPath, filename, len + 1 );
         }
         g_free( filename );
 

--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -305,13 +305,13 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
         {
             size_t len = strlen(filename);
             *outPath = NFDi_Malloc( len + 1 );
-            memcpy( *outPath, filename, len + 1 );
             if ( !*outPath )
             {
                 g_free( filename );
                 gtk_widget_destroy(dialog);
                 return NFD_ERROR;
             }
+            memcpy( *outPath, filename, len + 1 );
         }
         g_free(filename);
 
@@ -358,13 +358,13 @@ nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
         {
             size_t len = strlen(filename);
             *outPath = NFDi_Malloc( len + 1 );
-            memcpy( *outPath, filename, len + 1 );
             if ( !*outPath )
             {
                 g_free( filename );
                 gtk_widget_destroy(dialog);
                 return NFD_ERROR;
             }
+            memcpy( *outPath, filename, len + 1 );
         }
         g_free(filename);
 


### PR DESCRIPTION
- Commit 1728cb7da25b61e1bbb196eec53700aa679a029b moves `memcpy()` further down below to avoid passing a potential NULL pointer after a failed memory allocation.
- Commit 8bdd02dd6160843f1368e39e892f2f3ce4dee7a4 adds a wrapper for releasing memory of allocated paths. The paths are allocated with `NFDi_Malloc()`, so release them with `NFDi_Free()` for consistency.

Tested on 64-bit Linux (GCC and Clang), 64-bit Windows 10 (Visual Studio).
