### PR TITLE
Allow compiling without extra include path

### DIFF
--- a/src/nfd_cocoa.m
+++ b/src/nfd_cocoa.m
@@ -5,7 +5,7 @@
  */
 
 #include <AppKit/AppKit.h>
-#include "nfd.h"
+#include "include/nfd.h"
 #include "nfd_common.h"
 
 static NSArray *BuildAllowedFileTypes( const char *filterList )

--- a/src/nfd_common.c
+++ b/src/nfd_common.c
@@ -4,6 +4,11 @@
   http://www.frogtoss.com/labs
  */
 
+ // Disable warning using strncat()
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>

--- a/src/nfd_common.h
+++ b/src/nfd_common.h
@@ -10,7 +10,7 @@
 #ifndef _NFD_COMMON_H
 #define _NFD_COMMON_H
 
-#include "nfd.h"
+#include "include/nfd.h"
 
 #include <stdint.h>
 

--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <string.h>
 #include <gtk/gtk.h>
-#include "nfd.h"
+#include "include/nfd.h"
 #include "nfd_common.h"
 
 

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -11,6 +11,10 @@
 #define _WIN32_WINNT _WIN32_WINNT_VISTA
 #endif
 
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
 #include <crtdbg.h>

--- a/src/nfd_zenity.c
+++ b/src/nfd_zenity.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
-#include "nfd.h"
+#include "include/nfd.h"
 #include "nfd_common.h"
 
 #define SIMPLE_EXEC_IMPLEMENTATION


### PR DESCRIPTION
As a small change, if the source files of the libraries use relative include path `include/nfd.h` instead of `nfd.h` this would allow compiling the library without adding extra include paths in the compiler command-line, which is quite a convenience.

Encloded the PR with this suggested change.

e.g. I have a project where we include nfd.h only in 1 place of the whole project so it's also included with relative path e.g. `#include "libs/nativefiledialog/include/nfd.h`.

