### PR TITLE
GTK: Work around X11 focus issue (Fixes #79)

### DIFF
--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -165,6 +165,19 @@ static void WaitForCleanup(void)
     while (gtk_events_pending())
         gtk_main_iteration();
 }
+
+static void ConfigureFocus(GtkWidget *dialog)
+{
+#if defined(GDK_WINDOWING_X11)
+    /* Work around focus issue on X11 (https://github.com/mlabbe/nativefiledialog/issues/79) */
+    gtk_widget_show_all(dialog);
+    if (GDK_IS_X11_DISPLAY(gdk_display_get_default())) {
+        GdkWindow *window = gtk_widget_get_window(dialog);
+        gdk_window_set_events(window, gdk_window_get_events(window) | GDK_PROPERTY_CHANGE_MASK);
+        gtk_window_present_with_time(GTK_WINDOW(dialog), gdk_x11_get_server_time(window));
+    }
+#endif /* defined(GDK_WINDOWING_X11) */
+}
                                  
 /* public */
 
@@ -194,15 +207,7 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
     /* Set the default path */
     SetDefaultPath(dialog, defaultPath);
 
-#if defined(GDK_WINDOWING_X11)
-    /* Work around focus issue on X11 (https://github.com/mlabbe/nativefiledialog/issues/79) */
-    gtk_widget_show_all(dialog);
-    if (GDK_IS_X11_DISPLAY(gdk_display_get_default())) {
-        GdkWindow *window = gtk_widget_get_window(dialog);
-        gdk_window_set_events(window, gdk_window_get_events(window) | GDK_PROPERTY_CHANGE_MASK);
-        gtk_window_present_with_time(GTK_WINDOW(dialog), gdk_x11_get_server_time(window));
-    }
-#endif /* defined(GDK_WINDOWING_X11) */
+    ConfigureFocus(dialog);
 
     result = NFD_CANCEL;
     if ( gtk_dialog_run( GTK_DIALOG(dialog) ) == GTK_RESPONSE_ACCEPT )
@@ -262,6 +267,8 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
     /* Set the default path */
     SetDefaultPath(dialog, defaultPath);
 
+    ConfigureFocus(dialog);
+
     result = NFD_CANCEL;
     if ( gtk_dialog_run( GTK_DIALOG(dialog) ) == GTK_RESPONSE_ACCEPT )
     {
@@ -308,6 +315,8 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
 
     /* Set the default path */
     SetDefaultPath(dialog, defaultPath);
+
+    ConfigureFocus(dialog);
     
     result = NFD_CANCEL;    
     if ( gtk_dialog_run( GTK_DIALOG(dialog) ) == GTK_RESPONSE_ACCEPT )
@@ -361,6 +370,8 @@ nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
 
     /* Set the default path */
     SetDefaultPath(dialog, defaultPath);
+
+    ConfigureFocus(dialog);
     
     result = NFD_CANCEL;    
     if ( gtk_dialog_run( GTK_DIALOG(dialog) ) == GTK_RESPONSE_ACCEPT )

--- a/src/nfd_gtk.c
+++ b/src/nfd_gtk.c
@@ -8,6 +8,9 @@
 #include <assert.h>
 #include <string.h>
 #include <gtk/gtk.h>
+#if defined(GDK_WINDOWING_X11)
+#include <gdk/gdkx.h>
+#endif /* defined(GDK_WINDOWING_X11) */
 #include "nfd.h"
 #include "nfd_common.h"
 
@@ -190,6 +193,16 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
 
     /* Set the default path */
     SetDefaultPath(dialog, defaultPath);
+
+#if defined(GDK_WINDOWING_X11)
+    /* Work around focus issue on X11 (https://github.com/mlabbe/nativefiledialog/issues/79) */
+    gtk_widget_show_all(dialog);
+    if (GDK_IS_X11_DISPLAY(gdk_display_get_default())) {
+        GdkWindow *window = gtk_widget_get_window(dialog);
+        gdk_window_set_events(window, gdk_window_get_events(window) | GDK_PROPERTY_CHANGE_MASK);
+        gtk_window_present_with_time(GTK_WINDOW(dialog), gdk_x11_get_server_time(window));
+    }
+#endif /* defined(GDK_WINDOWING_X11) */
 
     result = NFD_CANCEL;
     if ( gtk_dialog_run( GTK_DIALOG(dialog) ) == GTK_RESPONSE_ACCEPT )


### PR DESCRIPTION
Verified under Ubuntu 20.04.1 LTS with Gtk 3.24.20 and the example code in #79.

Both "Ubuntu" (X11) and "Ubuntu Wayland" (Wayland) sessions tested; X11 now behaves correctly for the second invocation of the dialog, Wayland worked already before but did not regress with this in my testing (the compile-time `#if` checks if Gtk has been compiled with X11 support at all, the run-time `GDK_IS_X11_DISPLAY` checks if we're currently running in an X11 session).

All credits go to @mborgerson, I merely "ported" (cargo-culted) it from https://github.com/guillaumechereau/noc/pull/11 and tested it.