### PR TITLE
Zenity: add --confirm-overwrite for save dialog

### DIFF
--- a/src/nfd_zenity.c
+++ b/src/nfd_zenity.c
@@ -248,6 +248,7 @@ NFD_SaveDialog(const nfdchar_t* filterList, const nfdchar_t* defaultPath, nfdcha
     command[1] = strdup("--file-selection");
     command[2] = strdup("--title=Save File");
     command[3] = strdup("--save");
+    command[4] = strdup("--confirm-overwrite");
 
     char*       stdOut = NULL;
     nfdresult_t result =


### PR DESCRIPTION
Zenity: The save dialog now prompts the user for confirmation if the selected path already exists.