### PR TITLE
Fix modal disable/enable behavior on Win32

### DIFF
--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -444,7 +444,7 @@ NFD_OpenDialog(const nfdchar_t* filterList, const nfdchar_t* defaultPath, nfdcha
     SetDefaultFile(fileOpenDialog, defaultPath);
 
     // Show the dialog.
-    result = fileOpenDialog->Show(NULL);
+    result = fileOpenDialog->Show(::GetActiveWindow());
     if (SUCCEEDED(result)) {
         // Get the file name
         ::IShellItem* shellItem(NULL);
@@ -542,7 +542,7 @@ NFD_OpenDialogMultiple(const nfdchar_t* filterList,
     }
 
     // Show the dialog.
-    result = fileOpenDialog->Show(NULL);
+    result = fileOpenDialog->Show(::GetActiveWindow());
     if (SUCCEEDED(result)) {
         IShellItemArray* shellItems;
         result = fileOpenDialog->GetResults(&shellItems);
@@ -613,7 +613,7 @@ NFD_SaveDialog(const nfdchar_t* filterList, const nfdchar_t* defaultPath, nfdcha
     SetDefaultFile(fileSaveDialog, defaultPath);
 
     // Show the dialog.
-    result = fileSaveDialog->Show(NULL);
+    result = fileSaveDialog->Show(::GetActiveWindow());
     if (SUCCEEDED(result)) {
         // Get the file name
         ::IShellItem* shellItem;
@@ -698,7 +698,7 @@ NFD_PickFolder(const nfdchar_t* defaultPath, nfdchar_t** outPath)
     }
 
     // Show the dialog to the user
-    result = fileDialog->Show(NULL);
+    result = fileDialog->Show(::GetActiveWindow());
     if (SUCCEEDED(result)) {
         // Get the folder name
         ::IShellItem* shellItem(NULL);


### PR DESCRIPTION
This PR fixes the modal behavior of native file dialogs on Win32. Previously, opening a native file dialog would leave the calling window enabled. This is not how NFD behaves on macOS, though I do not know how it behaves on Linux.

More importantly, this issue exposes folks with immediate-mode GUI libraries like Dear ImGui to crashes on Windows. If you use `WM_SIZING` messages or similar to redraw an immediate mode GUI, but an NFD is open because of a call _from_ the GUI, then a user can break things by resizing the calling window with an NFD still open. Dear ImGui, at least, does not support recursive UI rendering.

This fix simply passes the calling window handle to `fileOpenDialog->Show()`, which it gets from [GetActiveWindow()](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getactivewindow). If `GetActiveWindow()` can't get a handle, it returns `NULL` anyways, so this change should not negatively impact existing projects. If anyone prefers to avoid disabling the base window when opening an NFD, then I'd argue that should be an API change, because again, this is the default behavior for NFD on macOS.

I tested this with Clang and MSVC on Win32.