### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ The makefile offers up to four options, with `release_x64` as the default.
     make config=debug_x86
     make config=debug_x64
 
+### Installing nativefiledialog (vcpkg)
+
+Alternatively, you can build and install nativefiledialog using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install nativefiledialog
+
+The nativefiledialog port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Compiling Your Programs ###
 
  1. Add `src/include` to your include search path.


### PR DESCRIPTION
`nativefiledialog` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `nativefiledialog` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `nativefiledialog`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/nativefiledialog/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊