### PR TITLE
Prevent macro overwrite warning

### DIFF
--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -8,7 +8,12 @@
 #ifdef __MINGW32__
 // Explicitly setting NTDDI version, this is necessary for the MinGW compiler
 #define NTDDI_VERSION NTDDI_VISTA
+
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT   // Prevent a warning about overwriting an existing define by first undefining it
+#endif
 #define _WIN32_WINNT _WIN32_WINNT_VISTA
+
 #endif
 
 #define _CRTDBG_MAP_ALLOC


### PR DESCRIPTION
My system: Windows 10, CLion + MinGW

When compiling there is a warning that the macro `_WIN32_WINNT` is being redefined. I simply added a check to undefine it first, which removes the warning makes it work seamlessly on any system.

Please merge the request soon if everything is good with it. Thank you, this library is awesome!